### PR TITLE
Update function names and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ const buffer = toPermissionsBuffer(permissionData);
 Likewise to [toPermissionsBuffer](#topermissionsbuffer) you can also get the permissiondata from a buffer:
 
 ```ts
-const permissionData = fromBuffer(buffer);
+const permissionData = fromPermissionsBuffer(buffer);
 ```
 
 ### toBitString
@@ -136,15 +136,15 @@ const permissionData = fromBuffer(buffer);
 Converting the permissiondata to bitstring is as easy as:
 
 ```ts
-const bitstring = toBitString(permissionData);
+const bitstring = toPermissionsBitString(permissionData);
 ```
 
 ### toString
 
-Converting the permissiondata to string is as easy as:
+Since permissionData is simply a BigInt, you can convert it to a string like so:
 
 ```ts
-const string = toString(permissionData);
+const string = permissionData.toString();
 ```
 
 ## Contributors

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,16 +2,16 @@ type PermissionData = bigint;
 type Permissions = number;
 
 export const EMPTY_PERMISSIONS = BigInt(0);
-export const convertToBit = (b: number | bigint) => BigInt(1) << BigInt(b);
+export const PermissionsToBit = (b: number | bigint) => BigInt(1) << BigInt(b);
 export const hasPermission = <K extends Permissions>(
     data: PermissionData,
     permission: K
-) => (data & convertToBit(permission)) > 0;
+) => (data & PermissionsToBit(permission)) > 0;
 export const grantPermission = <K extends Permissions>(
     data: PermissionData,
     ...permission: K[]
 ) => {
-    for (const perm of permission) data |= convertToBit(perm);
+    for (const perm of permission) data |= PermissionsToBit(perm);
 
     return data;
 };
@@ -19,7 +19,7 @@ export const removePermission = <K extends Permissions>(
     data: PermissionData,
     ...permission: K[]
 ) => {
-    for (const perm of permission) data &= ~convertToBit(perm);
+    for (const perm of permission) data &= ~PermissionsToBit(perm);
 
     return data;
 };
@@ -37,7 +37,7 @@ export const toPermissionsBuffer = (data: PermissionData): Buffer => {
     return Buffer.from(arrayBuffer);
 };
 
-export const fromBuffer = (buffer: Buffer) => {
+export const fromPermissionsBuffer = (buffer: Buffer) => {
     const view = new Uint8Array(buffer);
 
     let bits = BigInt(0);
@@ -48,7 +48,7 @@ export const fromBuffer = (buffer: Buffer) => {
     return bits;
 };
 
-export const toBitString = (data: PermissionData) => data.toString(2);
+export const toPermissionsBitString = (data: PermissionData) => data.toString(2);
 
 export const generatePermissions = (root: bigint) => {
     return {
@@ -58,7 +58,7 @@ export const generatePermissions = (root: bigint) => {
         remove: (...permission: Permissions[]) =>
             (root = removePermission(root, ...permission)),
         toBuffer: () => toPermissionsBuffer(root),
-        toBitString: () => toBitString(root),
+        toBitString: () => toPermissionsBitString(root),
         toString: () => root.toString(),
     };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,16 +2,16 @@ type PermissionData = bigint;
 type Permissions = number;
 
 export const EMPTY_PERMISSIONS = BigInt(0);
-export const PermissionsToBit = (b: number | bigint) => BigInt(1) << BigInt(b);
+export const permissionsToBit = (b: number | bigint) => BigInt(1) << BigInt(b);
 export const hasPermission = <K extends Permissions>(
     data: PermissionData,
     permission: K
-) => (data & PermissionsToBit(permission)) > 0;
+) => (data & permissionsToBit(permission)) > 0;
 export const grantPermission = <K extends Permissions>(
     data: PermissionData,
     ...permission: K[]
 ) => {
-    for (const perm of permission) data |= PermissionsToBit(perm);
+    for (const perm of permission) data |= permissionsToBit(perm);
 
     return data;
 };
@@ -19,7 +19,7 @@ export const removePermission = <K extends Permissions>(
     data: PermissionData,
     ...permission: K[]
 ) => {
-    for (const perm of permission) data &= ~PermissionsToBit(perm);
+    for (const perm of permission) data &= ~permissionsToBit(perm);
 
     return data;
 };


### PR DESCRIPTION
Update the function names to be a bit more specific to avoid overlapping functions from other packages.

toString was not a method the package exports (or creates). Since it's a just a bigint we can just use `userPerm.toString()`